### PR TITLE
make the send button a form input

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,20 +23,23 @@
             </div>
             
         <div id="retrocord">
-            <select class="retrocordcom" id="servers" name="servers">
-                <option value="test">TestServer</option>
-            </select>
-
-            <select class="retrocordcom" id="channels" name="channels">
-                <option value="test">TestChannel</option>
-            </select>
+            <form>
+                <select class="retrocordcom" id="servers" name="servers">
+                    <option value="test">TestServer</option>
+                </select>
+    
+                <select class="retrocordcom" id="channels" name="channels">
+                    <option value="test">TestChannel</option>
+                </select>
+                
+                <input id="msgin" type="text" placeholder="Write your message here">
+                <input type="submit" id="msgsub" value="Send">
+                
+                <div class="retrocordcom" id="chat">
+                </div>
+                <footer class="retrocordcom" id="MOTD" class="text"></footer>
+            </form>
             
-            <input id="msgin" type="text" placeholder="Write your message here">
-            <button id="msgsub">Send</button>
-            
-            <div class="retrocordcom" id="chat">
-            </div>
-            <footer class="retrocordcom" id="MOTD" class="text"></footer>
         </div>
     </body>
 </html>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -153,7 +153,7 @@ document.getElementById("login").onclick = async () => {
     }
 }
 
-document.getElementById("msgsub").onclick = () => {
+document.getElementById("msgsub").onclick = (event) => {
     let val = document.getElementById("msgin").value
     console.log(val.substr(0, 4))
     if (val.substr(0, 4) == "CMD:") { 
@@ -177,7 +177,7 @@ document.getElementById("msgsub").onclick = () => {
         servercon.send(JSON.stringify({action: 101, token: token, payload: {content: document.getElementById('msgin').value.trim(), channel: document.getElementById('channels').value, server: document.getElementById('servers').value}}))
     }
     document.getElementById("msgin").value = '';
-
+    event.preventDefault();
 }
 
 


### PR DESCRIPTION
This simple change now allows to send messages with the 'enter' key instead of clicking the 'Send' button with a mouse